### PR TITLE
feat: Implement custom exception, remove unnecessary code

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ $ git clone https://github.com/alphahorizonio/consumat.io-backend.git
 $ pip install -r requirements.txt
 $ export TMDB_KEY=<YOUR_TMDB_API_KEY>
 $ export FLASK_APP=./consumatio/external/api.py
-$ export PORT=5000
 $ flask run
 ```
 

--- a/consumatio/external/api.py
+++ b/consumatio/external/api.py
@@ -134,9 +134,3 @@ def graphql_server() -> str:
 
     status_code = 200 if success else 400
     return jsonify(result), status_code
-
-
-port = int(os.environ['PORT'])
-
-if __name__ == "__main__":
-    app.run(debug=True, port=port, host="0.0.0.0")

--- a/consumatio/external/api.py
+++ b/consumatio/external/api.py
@@ -10,7 +10,6 @@ from flask_cors import CORS
 from ariadne.constants import PLAYGROUND_HTML
 from consumatio.external.exceptions import UndefinedEnvironmentVariable
 import os
-import sys
 
 app = Flask(__name__)
 CORS(app)

--- a/consumatio/external/api.py
+++ b/consumatio/external/api.py
@@ -8,7 +8,9 @@ from consumatio.usecases.search_details import *
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 from ariadne.constants import PLAYGROUND_HTML
+from consumatio.external.exceptions import UndefinedEnvironmentVariable
 import os
+import sys
 
 app = Flask(__name__)
 CORS(app)
@@ -16,13 +18,18 @@ CORS(app)
 query = QueryType()
 
 
-# couldn't add type annotation on this parameter
-def tmdb_client(api_key=os.getenv('TMDB_KEY')) -> object:
+def tmdb_client() -> object:
     """
     Create a tmdb client.
     :param api_key: <str> API key for tmdb provided in an environment variable
     :return: <object> Tmdb object
     """
+    api_key = os.getenv('TMDB_KEY')
+
+    if (api_key == None):
+        raise UndefinedEnvironmentVariable(
+            "Please specify a valid API key for TMDB_KEY environment variable")
+
     return Tmdb(api_key)
 
 

--- a/consumatio/external/exceptions.py
+++ b/consumatio/external/exceptions.py
@@ -1,0 +1,5 @@
+class UndefinedEnvironmentVariable(Exception):
+    """
+    Exception raised when TMDB_KEY environment variable is not set
+    """
+    pass


### PR DESCRIPTION
Closes https://github.com/alphahorizonio/consumat.io/issues/59

"flask run" actually does not use the app.run() method at all. It doesn't even call the "__name__" method. I just removed the code that is not in use. If we still want to allow to specify a custom port, we need to set the "FLASK_RUN_PORT" environment variable or e.g. "flask run --port=5000". 