### PR TITLE
fix: Allow gunicorn to resolve `api`

### DIFF
--- a/consumatio/external/api.py
+++ b/consumatio/external/api.py
@@ -245,3 +245,5 @@ port = int(os.environ['PORT'])
 if __name__ == "__main__":
     migrate.init_app(app, db)
     app.run(debug=True, port=port, host="0.0.0.0")
+
+api = app


### PR DESCRIPTION
Hotfix for https://github.com/alphahorizonio/consumat.io/issues/102