### PR TITLE
Create main.py method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out
 __pycache__
 venv
+.vscode/.ropeproject

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 	mkdir -p /tmp/out
 	mkdir -p /tmp/build/build-$$(uname -m)
 	mkdir -p /tmp/spec/spec-$$(uname -m)
-	pyinstaller -n consumatio-backend.linux-$$(uname -m) --distpath /tmp/out --workpath /tmp/build/build-$$(uname -m) --specpath /tmp/spec/spec-$$(uname -m) --onefile ./consumatio/external/api.py
+	pyinstaller -n consumatio-backend.linux-$$(uname -m) --distpath /tmp/out --workpath /tmp/build/build-$$(uname -m) --specpath /tmp/spec/spec-$$(uname -m) --onefile main.py
 
 	# Stage dynamically-linked binaries
 	mkdir -p out
@@ -24,7 +24,7 @@ install: release
 	sudo install out/release/consumatio-backend.linux-$$(uname -m) /usr/local/bin/consumatio-backend
 	
 dev:
-	DEBUG=true PORT=5000 python3 -m consumatio.external.api
+	DEBUG=true PORT=5000 python3 main.py
 
 clean:
 	rm -rf out

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 	mkdir -p /tmp/out
 	mkdir -p /tmp/build/build-$$(uname -m)
 	mkdir -p /tmp/spec/spec-$$(uname -m)
-	pyinstaller -n consumatio-backend.linux-$$(uname -m) --distpath /tmp/out --workpath /tmp/build/build-$$(uname -m) --specpath /tmp/spec/spec-$$(uname -m) --onefile main.py
+	pyinstaller -n consumatio-backend.linux-$$(uname -m) --distpath /tmp/out --workpath /tmp/build/build-$$(uname -m) --specpath /tmp/spec/spec-$$(uname -m) --onefile main.py --add-data $${PWD}/consumatio/external/api.graphql:consumatio/external/api.graphql --add-data $${PWD}/migrations:migrations --hidden-import logging.config
 
 	# Stage dynamically-linked binaries
 	mkdir -p out
@@ -24,7 +24,7 @@ install: release
 	sudo install out/release/consumatio-backend.linux-$$(uname -m) /usr/local/bin/consumatio-backend
 	
 dev:
-	DEBUG=true PORT=5000 python3 main.py
+	DEBUG=true python3 main.py
 
 clean:
 	rm -rf out

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn -b :$PORT --chdir ./consumatio/external api:api
+web: gunicorn -b :$PORT main:app

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ docker run --name consumatio-postgres -d -e POSTGRES_USER=consumatio-postgres 
 # Install dependencies
 $ make depend
 # Start the backend
-$ DATABASE_URI="postgresql://consumatio-postgres:consumatio-postgres@localhost:5432/consumatio-postgres" TMDB_KEY="mytmdbkey" BACKEND_SECRET="mysecret" make dev
+$ TMDB_KEY="mytmdbkey" BACKEND_SECRET="mysecret" make dev
 ```
 
 The backend should now be started and the GraphQL playground should be available on [http://localhost:5000/](http://localhost:5000/). Whenever you change a source file, the backend will automatically be re-compiled and restarted.
@@ -80,7 +80,7 @@ To authorize in the playground, set the following HTTP headers:
 If you want to create and apply a migration, run the following; migrations are also applied ("upgraded") automatically on startup:
 
 ```shell
-$ MSG="mymigrationdescription" DATABASE_URI="postgresql://consumatio-postgres:consumatio-postgres@localhost:5432/consumatio-postgres" make migrations
+$ MSG="mymigrationdescription" make migrations
 ```
 
 You can also connect using `psql`:

--- a/consumatio/app.py
+++ b/consumatio/app.py
@@ -1,0 +1,11 @@
+class App:
+    def __init__(self, tmdb_key, backend_secret, database_uri, port, debug):
+        self.tmdb_key = tmdb_key
+        self.backend_secret = backend_secret
+        self.database_uri = database_uri
+        self.port = port
+        self.debug = debug
+
+    def run(self):
+        print(self.tmdb_key, self.backend_secret, self.database_uri, self.port,
+              self.debug)

--- a/consumatio/app.py
+++ b/consumatio/app.py
@@ -1,3 +1,17 @@
+import os
+
+from flask import Flask
+from flask_cors import CORS
+from flask_migrate import Migrate, upgrade
+
+from consumatio.external.api import get_schema
+from consumatio.external.db import Database
+from consumatio.external.logger import get_logger_instance
+from consumatio.external.models import *
+from consumatio.external.routes import register_routes
+from consumatio.external.tmdb import Tmdb
+
+
 class App:
     def __init__(self, tmdb_key, backend_secret, database_uri, port, debug):
         self.tmdb_key = tmdb_key
@@ -6,6 +20,40 @@ class App:
         self.port = port
         self.debug = debug
 
+    def configure(self):
+        # Create the app
+        app = Flask(__name__)
+
+        # Disable CORS
+        CORS(app)
+
+        # Setup the TMDB API client
+        tmdb = Tmdb(self.tmdb_key, db)
+
+        # Set up the database
+        database = Database(db)
+        app.config['SQLALCHEMY_DATABASE_URI'] = self.database_uri
+        app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = True
+
+        # Get the executable schema
+        schema = get_schema(tmdb, database)
+
+        # Setup migrations
+        migrate = Migrate(app, db)
+        db.init_app(app)
+        migrate.init_app(app, db)
+
+        # Run migrations
+        with app.app_context():
+            upgrade(directory=os.path.join(os.path.dirname(__file__), "..",
+                                           "migrations"))
+
+        # Register the routes
+        register_routes(app, schema, self.backend_secret)
+
+        # Expose the Flask app
+        self.app = app
+
     def run(self):
-        print(self.tmdb_key, self.backend_secret, self.database_uri, self.port,
-              self.debug)
+        # Start the app
+        self.app.run(debug=self.debug, port=self.port, host="0.0.0.0")

--- a/consumatio/constants.py
+++ b/consumatio/constants.py
@@ -1,0 +1,2 @@
+CONSUMATIO_NAMESPACE_HEADER_KEY = 'X-Consumatio-Namespace'
+CONSUMATIO_SECRET_HEADER_KEY = 'X-Consumatio-Secret'

--- a/consumatio/external/api.py
+++ b/consumatio/external/api.py
@@ -1,396 +1,300 @@
-from ariadne import ObjectType, QueryType, make_executable_schema, graphql_sync, load_schema_from_path, UnionType, MutationType
-from consumatio.external.tmdb import Tmdb
-from consumatio.usecases.set_number_of_watched_episodes import *
-from consumatio.usecases.get_movie import *
-from consumatio.usecases.get_tv import *
-from consumatio.usecases.get_season import *
+import os
+
+from ariadne import (MutationType, ObjectType, QueryType, UnionType,
+                     graphql_sync, load_schema_from_path,
+                     make_executable_schema)
+from consumatio.constants import CONSUMATIO_NAMESPACE_HEADER_KEY
+from consumatio.external.logger import get_logger_instance
 from consumatio.usecases.get_episode import *
-from consumatio.usecases.get_search import *
-from consumatio.usecases.get_popular import *
-from consumatio.usecases.get_tv_seasons import *
-from consumatio.usecases.get_season_episodes import *
-from consumatio.usecases.get_watch_count import *
 from consumatio.usecases.get_list import *
+from consumatio.usecases.get_movie import *
+from consumatio.usecases.get_popular import *
+from consumatio.usecases.get_search import *
+from consumatio.usecases.get_season import *
+from consumatio.usecases.get_season_episodes import *
+from consumatio.usecases.get_tv import *
+from consumatio.usecases.get_tv_seasons import *
+from consumatio.usecases.get_watch_count import *
 from consumatio.usecases.get_watch_time import *
 from consumatio.usecases.set_favorite import *
+from consumatio.usecases.set_number_of_watched_episodes import *
 from consumatio.usecases.set_rating import *
 from consumatio.usecases.set_watch_status import *
-from consumatio.external.db import Database
-from flask import Flask, request, jsonify
+from flask import request
 from flask_cors import CORS
-from ariadne.constants import PLAYGROUND_HTML
-from consumatio.external.exceptions.undefined_environment_variable import UndefinedEnvironmentVariable
-from consumatio.external.models import *
-import os
-from flask import Flask
-from flask_migrate import Migrate, upgrade
-from consumatio.external.logger import get_logger_instance
-
-query = QueryType()
-
-
-@query.field("movie")
-def resolve_movie(*_, code: int, country: str) -> dict:
-    """
-    API endpoint for "movie" queries.
-    :param code: <int> Id of the movie to get details for
-    :param country: <str> Country abbreviation to get corresponding providers (e.g. "DE" -> Germany)
-    :return: <dict> Details of the movie
-    """
-    logger.info("Movie was queried -> code:{}, country:'{}'".format(
-        code, country))
-    external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
-    return get_movie(external_id, tmdb, code, country)
-
-
-@query.field("tv")
-def resolve_tv(*_, code: int, country: str) -> dict:
-    """
-    API endpoint for "tv" queries.
-    :param code: <int> Id of the tv show to get details for
-    :param country: <str> Country abbreviation to get corresponding providers (e.g. "DE" -> Germany)
-    :return: <dict> Details of the tv show
-    """
-    logger.info("TV was queried -> code:{}, country:'{}'".format(
-        code, country))
-    external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
-    return get_tv(external_id, tmdb, code, country)
-
-
-@query.field("season")
-def resolve_season(*_, code: int, seasonNumber: str) -> dict:
-    """
-    API endpoint for "season" queries.
-    :param code: <int> Id of the tv show to get details for
-    :param seasonNumber: <int> Number of the season to get details for
-    :return: <dict> Details of the season 
-    """
-    logger.info("Season was queried -> code:{}, season_number:{}".format(
-        code, seasonNumber))
-    external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
-    return get_season(external_id, tmdb, code, seasonNumber)
-
-
-@query.field("episode")
-def resolve_episode(*_, code: int, seasonNumber: int,
-                    episodeNumber: int) -> dict:
-    """
-    API endpoint for "episode" queries.
-    :param code: <int> Id of the tv show to get details for
-    :param seasonNumber: <int> Number of the season to get details for
-    :param episodeNumber: <int> Number of the episode to get details for
-    :return: <dict> Details of the episode
-    """
-    logger.info(
-        "Episode was queried -> code:{}, season_number:{}, episode_number:{}".
-        format(code, seasonNumber, episodeNumber))
-    external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
-    return get_episode(external_id, tmdb, code, seasonNumber, episodeNumber)
-
-
-@query.field("search")
-def resolve_search(*_, keyword: str, page: int) -> dict:
-    """
-    API endpoint for "search" queries.
-    :param keyword: <str> Search string
-    :param page: <int> Search page (minimum:1 maximum:1000)
-    :return: <dict> Results of the search
-    """
-    logger.info("Search was queried -> keyword:'{}'".format(keyword))
-    external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
-    return get_search(external_id, tmdb, keyword, page)
-
-
-@query.field("popular")
-def resolve_popular(*_, type: str, country: str, page: int) -> dict:
-    """
-    API endpoint for "popular" queries.
-    :param type: <str> Choose between "tv" or "movie" to get popular results
-    :param country: <str> Country abbreviation to get corresponding providers (e.g. "DE" -> Germany)
-    :param page: <int> Search page (minimum:1 maximum:1000)
-    :return: <dict> Details of the movie/tv
-    """
-    logger.info("Popular was queried -> type:'{}', country:'{}'".format(
-        type, country))
-    external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
-    return get_popular(external_id, tmdb, type, country, page)
-
-
-@query.field("tvSeasons")
-def resolve_tv_seasons(*_, code: int) -> list:
-    """
-    API endpoint for "tvSeasons" queries.
-    :param code: <int> Code of the TV show to get the seasons for
-    :return: list of dicts consisting of seasons
-    """
-    logger.info("TVSeasons was queried -> code:'{}'".format(code))
-    external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
-    return get_tv_seasons(external_id, tmdb, code)
-
-
-@query.field("seasonEpisodes")
-def resolve_season_episodes(*_, code: str, seasonNumber: int) -> dict:
-    """
-    API endpoint for "seasonEpisodes" queries.
-    :param code: <int> Code of the TV show to get the episodes for 
-    :param seasonNumber: <int> Number of the season to get the episodes for
-    :return: list of dicts consisting of episodes
-    """
-    logger.info(
-        "seasonEpisodes was queried -> code:'{}', seasonNumber:'{}'".format(
-            code, seasonNumber))
-    external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
-    return get_season_episodes(external_id, tmdb, code, seasonNumber)
-
-
-@query.field("watchCount")
-def resolve_watch_count(*_, type: str) -> int:
-    """
-    API endpoint for "watchCount" queries.
-    :param type: <str> Type to return count for (Movie, TV, genre, Episode)
-    :return: <int> Count of watched media of provided type
-    """
-    logger.info("watchCount was queired -> type:'{}'".format(type))
-    external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
-    return get_watch_count(tmdb, external_id, type)
-
-
-@query.field("watchTime")
-def resolve_watch_time(*_, type: str) -> int:
-    """
-    API endpoint for "watchTime" queries.
-    :param type: <str> Type to return count for (Movie, TV)
-    :return: <int> Runtime of watched media of provided type
-    """
-    logger.info("watchTime was queried -> type:'{}'".format((type)))
-    external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
-    return get_watch_time(tmdb, external_id, type)
-
-
-@query.field("list")
-def resolve_list(*_, type: str, watchStatus: str, favorite: bool) -> dict:
-    """
-    API endpoint for "list" queries.
-    :param type: <str> Choose between "tv", "movie", "season" and "episode"
-    :param watchStatus: <str> Choose between "Plan to watch", "Watching", "Dropped" and "Finished" or "any"
-    :param favorite: <bool> to query media marked as favorite (best used with watchStatus = "any")
-    :return: <dict> Movie, TV, Season or Episode
-    """
-    logger.info("List was queried -> type:'{}', watchStatus:'{}'".format(
-        type, watchStatus))
-    external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
-    return get_list(tmdb, external_id, type, watchStatus, favorite)
-
-
-mutation = MutationType()
-
-
-@mutation.field("favorite")
-def resolve_favorite(*_, code: int, type: str, favorite: bool,
-                     seasonNumber: int, episodeNumber: int) -> dict:
-    logger.info(
-        "favorite was queried -> type:'{}', code:'{}', seasonNumber:'{}', episodeNumber:'{}', favorite:'{}'"
-        .format(type, code, seasonNumber, episodeNumber, favorite))
-    external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
-    return set_favorite(tmdb, database, external_id, type, code, seasonNumber,
-                        episodeNumber, favorite)
-
-
-@mutation.field("rating")
-def resolve_rating(*_, code: int, type: str, rating: int) -> dict:
-    logger.info(
-        "rating was queried -> type:'{}', code:'{}', rating:'{}'".format(
-            type, code, rating))
-    external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
-    return set_rating(database, external_id, type, code, rating)
-
-
-@mutation.field("numberOfWatchedEpisodes")
-def resolve_number_of_watched_episodes(*_, code: int, seasonNumber: int,
-                                       numberOfWatchedEpisodes: int) -> dict:
-    logger.info(
-        "number of watched episodes was queried -> code:'{}', seasonNumber:'{}', numberOfWatchedEpisodes:'{}'"
-        .format(code, seasonNumber, numberOfWatchedEpisodes))
-    external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
-    return set_number_of_watched_episodes(tmdb, database, external_id, code,
-                                          seasonNumber,
-                                          numberOfWatchedEpisodes)
-
-
-@mutation.field("watchStatus")
-def resolve_watch_status(*_, code: int, type: str, watchStatus: str) -> dict:
-    logger.info(
-        "watchStatus was queried -> code:'{}', type:'{}', watchStatus:'{}'".
-        format(code, type, watchStatus))
-    external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
-    return set_watch_status(database, external_id, code, type, watchStatus)
-
-
-app = Flask(__name__)
-CORS(app)
-
-
-@app.route("/", methods=["GET"])
-def graphql_playground() -> str:
-    """
-    If get request was made on "/", route to playground.
-    :return: <str>, <statuscode> Return playground html with status code 200
-    """
-    # log.DEBUG("Routed to playground -> code:{}".format(200))
-    return PLAYGROUND_HTML, 200
-
-
-@app.route("/", methods=["POST"])
-def graphql_server() -> str:
-    """
-    If post request was made on "/", resolve the queries.
-    :return: <str>, <statuscode> Return response to request with statuscode (200 or 400)
-    """
-    data = request.get_json()
-
-    if (BACKEND_SECRET == None):
-        raise UndefinedEnvironmentVariable(
-            "Please specify a valid backend secret for BACKEND_SECRET environment variable"
-        )
-
-    if request.headers.get(CONSUMATIO_SECRET_HEADER_KEY) != BACKEND_SECRET:
-        status_code = 401
-
-        return "unauthorized", status_code
-
-    success, result = graphql_sync(schema,
-                                   data,
-                                   context_value=request,
-                                   debug=app.debug)
-
-    status_code = 200 if success else 400
-    return jsonify(result), status_code
-
-
-TMDB_KEY_KEY = os.getenv('TMDB_KEY')
-if (TMDB_KEY_KEY == None):
-    raise UndefinedEnvironmentVariable(
-        "Please specify a valid API key for TMDB_KEY environment variable")
-
-BACKEND_SECRET = os.getenv('BACKEND_SECRET')
-if (BACKEND_SECRET == None):
-    raise UndefinedEnvironmentVariable(
-        "Please specify a valid API key for BACKEND_SECRET environment variable"
-    )
-
-CONSUMATIO_NAMESPACE_HEADER_KEY = 'X-Consumatio-Namespace'
-if (CONSUMATIO_NAMESPACE_HEADER_KEY == None):
-    raise UndefinedEnvironmentVariable(
-        "Please specify a valid API key for CONSUMATIO_NAMESPACE_HEADER_KEY environment variable"
-    )
-
-CONSUMATIO_SECRET_HEADER_KEY = 'X-Consumatio-Secret'
-if (CONSUMATIO_SECRET_HEADER_KEY == None):
-    raise UndefinedEnvironmentVariable(
-        "Please specify a valid API key for CONSUMATIO_SECRET_HEADER_KEY environment variable"
-    )
-
-DATABASE_URI = os.getenv('DATABASE_URI')
-if (DATABASE_URI == None):
-    raise UndefinedEnvironmentVariable(
-        "Please sepcify a valid API key for DATABASE_URI environment variable")
-
-PORT = os.getenv("PORT")
-if (PORT == None):
-    raise UndefinedEnvironmentVariable(
-        "Please specify a valid API key for PORT environment variable")
-
-app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URI
-tmdb = Tmdb(TMDB_KEY_KEY, db)
-migrate = Migrate(app, db)
 
 logger = get_logger_instance()
 
-db.init_app(app)
 
-favorite = MutationType()
-favorite.set_field("favorite", resolve_favorite)
+def register_query_resolvers(query, tmdb):
+    @query.field("movie")
+    def resolve_movie(*_, code: int, country: str) -> dict:
+        """
+        API endpoint for "movie" queries.
+        :param code: <int> Id of the movie to get details for
+        :param country: <str> Country abbreviation to get corresponding providers (e.g. "DE" -> Germany)
+        :return: <dict> Details of the movie
+        """
+        logger.info("Movie was queried -> code:{}, country:'{}'".format(
+            code, country))
+        external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
+        return get_movie(external_id, tmdb, code, country)
 
-rating = MutationType()
-rating.set_field("rating", resolve_rating)
+    @query.field("tv")
+    def resolve_tv(*_, code: int, country: str) -> dict:
+        """
+        API endpoint for "tv" queries.
+        :param code: <int> Id of the tv show to get details for
+        :param country: <str> Country abbreviation to get corresponding providers (e.g. "DE" -> Germany)
+        :return: <dict> Details of the tv show
+        """
+        logger.info("TV was queried -> code:{}, country:'{}'".format(
+            code, country))
+        external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
+        return get_tv(external_id, tmdb, code, country)
 
-number_of_watched_episodes = MutationType()
-# TODO: Alias
-number_of_watched_episodes.set_field("numberOfWatchedEpisodes",
-                                     resolve_number_of_watched_episodes)
+    @query.field("season")
+    def resolve_season(*_, code: int, seasonNumber: str) -> dict:
+        """
+        API endpoint for "season" queries.
+        :param code: <int> Id of the tv show to get details for
+        :param seasonNumber: <int> Number of the season to get details for
+        :return: <dict> Details of the season 
+        """
+        logger.info("Season was queried -> code:{}, season_number:{}".format(
+            code, seasonNumber))
+        external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
+        return get_season(external_id, tmdb, code, seasonNumber)
 
-watch_status = MutationType()
-# TODO: Alias
-watch_status.set_field("watchStatus", resolve_watch_status)
+    @query.field("episode")
+    def resolve_episode(*_, code: int, seasonNumber: int,
+                        episodeNumber: int) -> dict:
+        """
+        API endpoint for "episode" queries.
+        :param code: <int> Id of the tv show to get details for
+        :param seasonNumber: <int> Number of the season to get details for
+        :param episodeNumber: <int> Number of the episode to get details for
+        :return: <dict> Details of the episode
+        """
+        logger.info(
+            "Episode was queried -> code:{}, season_number:{}, episode_number:{}"
+            .format(code, seasonNumber, episodeNumber))
+        external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
+        return get_episode(external_id, tmdb, code, seasonNumber,
+                           episodeNumber)
 
-movie = ObjectType("Movie")
-movie.set_alias("ratingAverage", "rating_average")
-movie.set_alias("releaseInitial", "release_date")
-movie.set_alias("backdropPath", "backdrop_path")
-movie.set_alias("posterPath", "poster_path")
-movie.set_alias("tmdbUrl", "tmdb_url")
-movie.set_alias("watchStatus", "watch_status")
-movie.set_alias("ratingUser", "rating_user")
+    @query.field("search")
+    def resolve_search(*_, keyword: str, page: int) -> dict:
+        """
+        API endpoint for "search" queries.
+        :param keyword: <str> Search string
+        :param page: <int> Search page (minimum:1 maximum:1000)
+        :return: <dict> Results of the search
+        """
+        logger.info("Search was queried -> keyword:'{}'".format(keyword))
+        external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
+        return get_search(external_id, tmdb, keyword, page)
 
-tv = ObjectType("TV")
-tv.set_alias("ratingAverage", "rating_average")
-tv.set_alias("releaseInitial", "first_air_date")
-tv.set_alias("releaseFinal", "last_air_date")
-tv.set_alias("backdropPath", "backdrop_path")
-tv.set_alias("posterPath", "poster_path")
-tv.set_alias("numberOfEpisodes", "number_of_episodes")
-tv.set_alias("numberOfSeasons", "number_of_seasons")
-tv.set_alias("tmdbUrl", "tmdb_url")
-tv.set_alias("watchStatus", "watch_status")
-tv.set_alias("ratingUser", "rating_user")
-tv.set_alias("directors", "creators")
+    @query.field("popular")
+    def resolve_popular(*_, type: str, country: str, page: int) -> dict:
+        """
+        API endpoint for "popular" queries.
+        :param type: <str> Choose between "tv" or "movie" to get popular results
+        :param country: <str> Country abbreviation to get corresponding providers (e.g. "DE" -> Germany)
+        :param page: <int> Search page (minimum:1 maximum:1000)
+        :return: <dict> Details of the movie/tv
+        """
+        logger.info("Popular was queried -> type:'{}', country:'{}'".format(
+            type, country))
+        external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
+        return get_popular(external_id, tmdb, type, country, page)
 
-season = ObjectType("Season")
-season.set_alias("tvCode", "tv_code")
-season.set_alias("seasonNumber", "season_number")
-season.set_alias("posterPath", "poster_path")
-season.set_alias("numberOfEpisodes", "number_of_episodes")
-season.set_alias("airDate", "air_date")
-season.set_alias("numberOfWatchedEpisodes", "number_of_watched_episodes")
+    @query.field("tvSeasons")
+    def resolve_tv_seasons(*_, code: int) -> list:
+        """
+        API endpoint for "tvSeasons" queries.
+        :param code: <int> Code of the TV show to get the seasons for
+        :return: list of dicts consisting of seasons
+        """
+        logger.info("TVSeasons was queried -> code:'{}'".format(code))
+        external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
+        return get_tv_seasons(external_id, tmdb, code)
 
-episode = ObjectType("Episode")
-episode.set_alias("episodeNumber", "episode_number")
-episode.set_alias("seasonNumber", "season_number")
-episode.set_alias("airDate", "air_date")
-episode.set_alias("ratingAverage", "rating_average")
-episode.set_alias("stillPath", "still_path")
+    @query.field("seasonEpisodes")
+    def resolve_season_episodes(*_, code: str, seasonNumber: int) -> dict:
+        """
+        API endpoint for "seasonEpisodes" queries.
+        :param code: <int> Code of the TV show to get the episodes for 
+        :param seasonNumber: <int> Number of the season to get the episodes for
+        :return: list of dicts consisting of episodes
+        """
+        logger.info(
+            "seasonEpisodes was queried -> code:'{}', seasonNumber:'{}'".
+            format(code, seasonNumber))
+        external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
+        return get_season_episodes(external_id, tmdb, code, seasonNumber)
 
-media_page = ObjectType("MediaPage")
-media_page.set_alias("totalPages", "total_pages")
+    @query.field("watchCount")
+    def resolve_watch_count(*_, type: str) -> int:
+        """
+        API endpoint for "watchCount" queries.
+        :param type: <str> Type to return count for (Movie, TV, genre, Episode)
+        :return: <int> Count of watched media of provided type
+        """
+        logger.info("watchCount was queired -> type:'{}'".format(type))
+        external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
+        return get_watch_count(tmdb, external_id, type)
 
-director = ObjectType("Director")
-director.set_alias("imagePath", "image_path")
+    @query.field("watchTime")
+    def resolve_watch_time(*_, type: str) -> int:
+        """
+        API endpoint for "watchTime" queries.
+        :param type: <str> Type to return count for (Movie, TV)
+        :return: <int> Runtime of watched media of provided type
+        """
+        logger.info("watchTime was queried -> type:'{}'".format((type)))
+        external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
+        return get_watch_time(tmdb, external_id, type)
 
-cast = ObjectType("Cast")
-cast.set_alias("imagePath", "image_path")
+    @query.field("list")
+    def resolve_list(*_, type: str, watchStatus: str, favorite: bool) -> dict:
+        """
+        API endpoint for "list" queries.
+        :param type: <str> Choose between "tv", "movie", "season" and "episode"
+        :param watchStatus: <str> Choose between "Plan to watch", "Watching", "Dropped" and "Finished" or "any"
+        :param favorite: <bool> to query media marked as favorite (best used with watchStatus = "any")
+        :return: <dict> Movie, TV, Season or Episode
+        """
+        logger.info("List was queried -> type:'{}', watchStatus:'{}'".format(
+            type, watchStatus))
+        external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
+        return get_list(tmdb, external_id, type, watchStatus, favorite)
 
-searchResult = UnionType("Media")
 
-database = Database(db)
+def register_mutation_resolvers(mutation, tmdb, database):
+    @mutation.field("favorite")
+    def resolve_favorite(*_, code: int, type: str, favorite: bool,
+                         seasonNumber: int, episodeNumber: int) -> dict:
+        logger.info(
+            "favorite was queried -> type:'{}', code:'{}', seasonNumber:'{}', episodeNumber:'{}', favorite:'{}'"
+            .format(type, code, seasonNumber, episodeNumber, favorite))
+        external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
+        return set_favorite(tmdb, database, external_id, type, code,
+                            seasonNumber, episodeNumber, favorite)
 
-type_defs = load_schema_from_path(
-    os.path.join(os.path.dirname(__file__), "api.graphql"))
+    @mutation.field("rating")
+    def resolve_rating(*_, code: int, type: str, rating: int) -> dict:
+        logger.info(
+            "rating was queried -> type:'{}', code:'{}', rating:'{}'".format(
+                type, code, rating))
+        external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
+        return set_rating(database, external_id, type, code, rating)
 
-schema = make_executable_schema(type_defs, query, mutation, rating,
-                                watch_status, movie, tv, season, episode,
-                                media_page, director, cast,
-                                number_of_watched_episodes, favorite)
+    @mutation.field("numberOfWatchedEpisodes")
+    def resolve_number_of_watched_episodes(
+            *_, code: int, seasonNumber: int,
+            numberOfWatchedEpisodes: int) -> dict:
+        logger.info(
+            "number of watched episodes was queried -> code:'{}', seasonNumber:'{}', numberOfWatchedEpisodes:'{}'"
+            .format(code, seasonNumber, numberOfWatchedEpisodes))
+        external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
+        return set_number_of_watched_episodes(tmdb, database, external_id,
+                                              code, seasonNumber,
+                                              numberOfWatchedEpisodes)
 
-migrate.init_app(app, db)
+    @mutation.field("watchStatus")
+    def resolve_watch_status(*_, code: int, type: str,
+                             watchStatus: str) -> dict:
+        logger.info(
+            "watchStatus was queried -> code:'{}', type:'{}', watchStatus:'{}'"
+            .format(code, type, watchStatus))
+        external_id = request.headers.get(CONSUMATIO_NAMESPACE_HEADER_KEY)
+        return set_watch_status(database, external_id, code, type, watchStatus)
 
-with app.app_context():
-    upgrade(directory=os.path.join(os.path.dirname(__file__), "..", "..",
-                                   "migrations"))
+    return resolve_favorite, resolve_rating, resolve_number_of_watched_episodes, resolve_watch_status
 
-api = app
 
-if __name__ == "__main__":
-    if os.getenv('DEBUG') != None:
-        app.run(debug=True, port=PORT, host="0.0.0.0")
-    else:
-        app.run(port=PORT, host="0.0.0.0")
+def get_schema(tmdb, database):
+    # Setup queries
+    query = QueryType()
+    register_query_resolvers(query, tmdb)
+
+    # Setup mutations
+    mutation = MutationType()
+    resolve_favorite, resolve_rating, resolve_number_of_watched_episodes, resolve_watch_status = register_mutation_resolvers(
+        mutation, tmdb, database)
+
+    # Register aliases for mutations
+    favorite = MutationType()
+    favorite.set_field("favorite", resolve_favorite)
+
+    rating = MutationType()
+    rating.set_field("rating", resolve_rating)
+
+    number_of_watched_episodes = MutationType()
+    # TODO: Alias
+    number_of_watched_episodes.set_field("numberOfWatchedEpisodes",
+                                         resolve_number_of_watched_episodes)
+
+    watch_status = MutationType()
+    # TODO: Alias
+    watch_status.set_field("watchStatus", resolve_watch_status)
+
+    # Register aliases for objects
+    movie = ObjectType("Movie")
+    movie.set_alias("ratingAverage", "rating_average")
+    movie.set_alias("releaseInitial", "release_date")
+    movie.set_alias("backdropPath", "backdrop_path")
+    movie.set_alias("posterPath", "poster_path")
+    movie.set_alias("tmdbUrl", "tmdb_url")
+    movie.set_alias("watchStatus", "watch_status")
+    movie.set_alias("ratingUser", "rating_user")
+
+    tv = ObjectType("TV")
+    tv.set_alias("ratingAverage", "rating_average")
+    tv.set_alias("releaseInitial", "first_air_date")
+    tv.set_alias("releaseFinal", "last_air_date")
+    tv.set_alias("backdropPath", "backdrop_path")
+    tv.set_alias("posterPath", "poster_path")
+    tv.set_alias("numberOfEpisodes", "number_of_episodes")
+    tv.set_alias("numberOfSeasons", "number_of_seasons")
+    tv.set_alias("tmdbUrl", "tmdb_url")
+    tv.set_alias("watchStatus", "watch_status")
+    tv.set_alias("ratingUser", "rating_user")
+    tv.set_alias("directors", "creators")
+
+    season = ObjectType("Season")
+    season.set_alias("tvCode", "tv_code")
+    season.set_alias("seasonNumber", "season_number")
+    season.set_alias("posterPath", "poster_path")
+    season.set_alias("numberOfEpisodes", "number_of_episodes")
+    season.set_alias("airDate", "air_date")
+    season.set_alias("numberOfWatchedEpisodes", "number_of_watched_episodes")
+
+    episode = ObjectType("Episode")
+    episode.set_alias("episodeNumber", "episode_number")
+    episode.set_alias("seasonNumber", "season_number")
+    episode.set_alias("airDate", "air_date")
+    episode.set_alias("ratingAverage", "rating_average")
+    episode.set_alias("stillPath", "still_path")
+
+    media_page = ObjectType("MediaPage")
+    media_page.set_alias("totalPages", "total_pages")
+
+    director = ObjectType("Director")
+    director.set_alias("imagePath", "image_path")
+
+    cast = ObjectType("Cast")
+    cast.set_alias("imagePath", "image_path")
+
+    searchResult = UnionType("Media")
+
+    # Read the GraphQL schema
+    type_defs = load_schema_from_path(
+        os.path.join(os.path.dirname(__file__), "api.graphql"))
+
+    # Connect the schema to the resolvers
+    return make_executable_schema(type_defs, query, mutation, rating,
+                                  watch_status, movie, tv, season, episode,
+                                  media_page, director, cast,
+                                  number_of_watched_episodes, favorite)

--- a/consumatio/external/api.py
+++ b/consumatio/external/api.py
@@ -295,7 +295,7 @@ if (DATABASE_URI == None):
     raise UndefinedEnvironmentVariable(
         "Please sepcify a valid API key for DATABASE_URI environment variable")
 
-PORT = int(os.environ['PORT'])
+PORT = os.getenv("PORT")
 if (PORT == None):
     raise UndefinedEnvironmentVariable(
         "Please specify a valid API key for PORT environment variable")

--- a/consumatio/external/routes.py
+++ b/consumatio/external/routes.py
@@ -1,0 +1,37 @@
+from ariadne import graphql_sync
+from ariadne.constants import PLAYGROUND_HTML
+from consumatio.constants import CONSUMATIO_SECRET_HEADER_KEY
+from flask import jsonify, request
+
+
+def register_routes(app, schema, backend_secret):
+    @app.route("/", methods=["GET"])
+    def graphql_playground() -> str:
+        """
+        If get request was made on "/", route to playground.
+        :return: <str>, <statuscode> Return playground html with status code 200
+        """
+        log.DEBUG("Routed to playground -> code:{}".format(200))
+
+        return PLAYGROUND_HTML, 200
+
+    @app.route("/", methods=["POST"])
+    def graphql_server() -> str:
+        """
+        If post request was made on "/", resolve the queries.
+        :return: <str>, <statuscode> Return response to request with statuscode (200 or 400)
+        """
+        data = request.get_json()
+
+        if request.headers.get(CONSUMATIO_SECRET_HEADER_KEY) != backend_secret:
+            status_code = 401
+
+            return "unauthorized", status_code
+
+        success, result = graphql_sync(schema,
+                                       data,
+                                       context_value=request,
+                                       debug=app.debug)
+
+        status_code = 200 if success else 400
+        return jsonify(result), status_code

--- a/main.py
+++ b/main.py
@@ -1,30 +1,76 @@
 #!/usr/bin/env python3
 
-import click
 import os
+
+import click
+
 from consumatio.app import App
+from consumatio.external.exceptions.undefined_environment_variable import \
+    UndefinedEnvironmentVariable
+
+DEFAULT_DATABASE_URI = "postgresql://consumatio-postgres:consumatio-postgres@localhost:5432/consumatio-postgres"
 
 
 @click.command()
-@click.option("--tmdb-key", help="API key for the TMDB API", required=True)
-@click.option("--backend-secret", help="Secret for the backend", required=True)
-@click.option(
-    "--database-uri",
-    default=
-    "postgresql://consumatio-postgres:consumatio-postgres@localhost:5432/consumatio-postgres",
-    help="URI for the database",
-    required=True)
+@click.option("--tmdb-key",
+              envvar="TMDB_KEY",
+              help="API key for the TMDB API",
+              required=True)
+@click.option("--backend-secret",
+              envvar="BACKEND_SECRET",
+              help="Secret for the backend",
+              required=True)
+@click.option("--database-uri",
+              default=DEFAULT_DATABASE_URI,
+              envvar="DATABASE_URI",
+              help="URI for the database",
+              required=True)
 @click.option("--port", default=5000, envvar="PORT", help="Port to listen on")
 @click.option("--debug",
               default=False,
               envvar="DEBUG",
               help="Enable debug mode")
-def consumatio_backend(tmdb_key, backend_secret, database_uri, port, debug):
+def run_consumatio_backend_cli(tmdb_key, backend_secret, database_uri, port,
+                               debug):
     """Backend for https://github.com/alphahorizonio/consumat.io."""
+    # Configure the app
     app = App(tmdb_key, backend_secret, database_uri, port, debug)
 
+    app.configure()
+
+    print(f"Listening on port {port}")
+
+    # Start the app
     app.run()
 
 
 if __name__ == '__main__':
-    consumatio_backend(auto_envvar_prefix="consumatio")
+    # Running as CLI
+    run_consumatio_backend_cli()
+else:
+    # Running with WSGI, so manually read env variables
+    tmdb_key = os.getenv("TMDB_KEY")
+    backend_secret = os.getenv("BACKEND_SECRET")
+    database_uri = os.getenv("DATABASE_URI")
+    port = os.getenv("PORT")
+    debug = os.getenv("DEBUG")
+
+    # Check if env variables are set
+    if tmdb_key == None:
+        raise UndefinedEnvironmentVariable(
+            "Please specify the TMDB_KEY env variable")
+    if backend_secret == None:
+        raise UndefinedEnvironmentVariable(
+            "Please specify the BACKEND_SECRET env variable")
+    if database_uri == None:
+        database_uri = DEFAULT_DATABASE_URI
+    if debug == None:
+        debug = False
+
+    # Configure the app
+    app = App(tmdb_key, backend_secret, database_uri, None, debug)
+
+    app.configure()
+
+    # Expose the Flask app instance to WSGI
+    api = app.app

--- a/main.py
+++ b/main.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import click
+import os
+from consumatio.app import App
+
+
+@click.command()
+@click.option("--tmdb-key", help="API key for the TMDB API", required=True)
+@click.option("--backend-secret", help="Secret for the backend", required=True)
+@click.option(
+    "--database-uri",
+    default=
+    "postgresql://consumatio-postgres:consumatio-postgres@localhost:5432/consumatio-postgres",
+    help="URI for the database",
+    required=True)
+@click.option("--port", default=5000, envvar="PORT", help="Port to listen on")
+@click.option("--debug",
+              default=False,
+              envvar="DEBUG",
+              help="Enable debug mode")
+def consumatio_backend(tmdb_key, backend_secret, database_uri, port, debug):
+    """Backend for https://github.com/alphahorizonio/consumat.io."""
+    app = App(tmdb_key, backend_secret, database_uri, port, debug)
+
+    app.run()
+
+
+if __name__ == '__main__':
+    consumatio_backend(auto_envvar_prefix="consumatio")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Flask-Migrate==2.7.0
 Flask-SQLAlchemy==2.5.1
 psycopg2-binary==2.8.6
 gunicorn==20.1.0
+click==8.0.1


### PR DESCRIPTION
This decomposes the current "messy" api.py and seperates concerns; it also allows for better re-use of resolvers etc. and unifies the WSGI/CLI startup.

Closes https://github.com/alphahorizonio/consumat.io/issues/124