### PR TITLE
Use tagged hydrun release

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Set up hydrun
         run: |
-          curl -L -o /tmp/hydrun https://github.com/pojntfx/hydrun/releases/download/latest/hydrun.linux-$(uname -m)
+          curl -L -o /tmp/hydrun "https://github.com/pojntfx/hydrun/releases/latest/download/hydrun.linux-$(uname -m)"
           sudo install /tmp/hydrun /usr/local/bin
       - name: Start database
         run: |


### PR DESCRIPTION
Hydrun now has tagged releases, which means that the consumatio backend will have to adapt it's download URL.