### PR TITLE
Use new `extra-args` hydrun flag

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,7 +32,7 @@ jobs:
           docker run --network consumatio-backend-testing --name consumatio-postgres -d -e POSTGRES_USER=consumatio-postgres -e POSTGRES_PASSWORD=consumatio-postgres -e POSTGRES_DB=consumatio-postgres -p 5432:5432 -v consumatio-postgres:/var/lib/postgresql/data postgres postgres -N 512
           sleep 5 # Wait for the DB to start
       - name: Test with hydrun
-        run: hydrun --extraArgs='--network consumatio-backend-testing -e DATABASE_URI=postgresql://consumatio-postgres:consumatio-postgres@consumatio-postgres:5432/consumatio-postgres' './Hydrunfile test'
+        run: hydrun --extra-args='--network consumatio-backend-testing -e DATABASE_URI=postgresql://consumatio-postgres:consumatio-postgres@consumatio-postgres:5432/consumatio-postgres' './Hydrunfile test'
       - name: Login to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v1

--- a/.github/workflows/hydrun.yaml
+++ b/.github/workflows/hydrun.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       - name: Set up hydrun
         run: |
-          curl -L -o /tmp/hydrun https://github.com/pojntfx/hydrun/releases/download/latest/hydrun.linux-$(uname -m)
+          curl -L -o /tmp/hydrun "https://github.com/pojntfx/hydrun/releases/latest/download/hydrun.linux-$(uname -m)"
           sudo install /tmp/hydrun /usr/local/bin
       - name: Start database
         run: |

--- a/.github/workflows/hydrun.yaml
+++ b/.github/workflows/hydrun.yaml
@@ -26,7 +26,7 @@ jobs:
           docker run --network consumatio-backend-testing --name consumatio-postgres -d -e POSTGRES_USER=consumatio-postgres -e POSTGRES_PASSWORD=consumatio-postgres -e POSTGRES_DB=consumatio-postgres -p 5432:5432 -v consumatio-postgres:/var/lib/postgresql/data postgres postgres -N 512
           sleep 5 # Wait for the DB to start
       - name: Test with hydrun
-        run: hydrun --extraArgs='--network consumatio-backend-testing -e DATABASE_URI=postgresql://consumatio-postgres:consumatio-postgres@consumatio-postgres:5432/consumatio-postgres' './Hydrunfile test'
+        run: hydrun --extra-args='--network consumatio-backend-testing -e DATABASE_URI=postgresql://consumatio-postgres:consumatio-postgres@consumatio-postgres:5432/consumatio-postgres' './Hydrunfile test'
       - name: Build backend binary with hydrun
         run: hydrun -a amd64,arm64,arm/v7 './Hydrunfile binary'
       - name: Fix permissions for built binary


### PR DESCRIPTION
This backports the `extra-args` hydrun flag to the build system.